### PR TITLE
Update daily commit script to show tracked markdown diffs

### DIFF
--- a/.claude/commands/daily.md
+++ b/.claude/commands/daily.md
@@ -17,21 +17,23 @@ date: TARGET_DATE
 
 ## Analysis
 
-Here are the items I want you to focus on for your analysis:
-- **Technical challenges solved** - what specific problems were encountered, how they were debugged, and what solutions were implemented. For this look specifically at code file diffs and at changes in plans that are reflected in .md files.
-- **New technologies, specific findings about how their idiosyncracies** - trials and mistakes lead, and research, lead to discoveries about why things won't work or work only in certain ways. This is useful knowledge that we want to surface. For that look in particular at .md files which un packs our thinking, our plans, what we tried, and our research.
-- **AI process improvements or setbacks** - the AI-assisted development process is harnessed using .md files. Some of them contain general instructions (claude.md), some capture automation processes (in .claude). And some others (those that contains plans, or logs of what happened for example) support the AI-assisted development process to store short-term memories mostly and keep track of what was done and what needs to be done. For these last ones, it's not so much the exact content than how they are used to support the development process that is interesting. So analyze all those files to identify if and how we changed the process.
+The analysis' goal is to surface:
+- **Why we did things** rather than what was done. So focus on the intent. This intent can play over multiple commits, so paying specific attention to the spec files and the plan files can help understand the underlying reason to do things. For each overarching challenge that we tackled: 
+  - Make it a single item
+  - Report on lower level challenges of interest. Specifically report  on the decisions that were made if there were multiple options, and if there is research that has been logged in the commits.
+- **What we learned** if there were some important learning items, ones that had some level of intricacies and required some research, summarize what was learnt.
+- **AI process improvements or setbacks** - the AI-assisted development process is harnessed using claude.md files. Document changes to this file that indicate a new policy or some instruction regarding a specific problem. But ignore changes that are documenting things that you already reported upon in the challenges we tackled.
 
-Each extracted item is formatted a new bullet point. And for each extracted item provide some details in the form of up to 3 sub-bullet points each of one sentence maximum.
+The report being about the daily activity is likely to be 1 to 10 items. And 0 sometimes. Ignore changes that are just content changes, or those for which there is no clear intent.
 
 It should look like so:
 - **Item title A**:
-  - Description sentence 1
-  - Description sentence 2
+  - Details: sentence 1
+  - Details: sentence 2
 - **Item title B**:
-  - Description sentence 1
-  - Description sentence 2
-  - Description sentence 3
+  - Details: sentence 1
+  - Details: sentence 2
+  - Details: sentence 3
 - An so on...
 
 

--- a/daily-logs/2025-09-25-daily-log(2).md
+++ b/daily-logs/2025-09-25-daily-log(2).md
@@ -1,0 +1,717 @@
+---
+title: "Activity Log - 2025-09-25"
+date: 2025-09-25
+---
+
+## ANALYSIS
+
+- **Daily command architecture overhaul to achieve maintainability**:
+  - Details: Intent was to replace complex multi-script system with single streamlined script for easier debugging and maintenance
+  - Details: Decision made to eliminate intermediate files and caching in favor of direct data flow from script to Claude
+
+- **GitHub API optimization through architectural research**:
+  - Details: Research revealed GitHub Search API only indexes default branches, limiting feature branch commit discovery
+  - Details: Chose commit-first approach (search by date) over repository-first approach for efficiency - single API call vs dozens
+
+- **Process improvement through structured planning methodology**:
+  - Details: Used detailed 95-task plan with 9 phases to manage complex refactoring, demonstrating systematic approach
+  - Details: Plan file served dual purpose as roadmap and documentation of implementation decisions and progress tracking
+
+## RAW COMMITS
+
+Repository: meaningfool/meaningfool-writing
+Commit: [a08b941c0391fa908413a7d862706827d1a91a56] Complete daily command refactoring implementation
+Description:
+  Successfully refactored /daily command from multi-script system to single streamlined script.
+
+  Changes:
+  - Completed all integration tests for various date formats
+  - Updated CLAUDE.md with /daily command documentation and examples
+  - Marked all plan items (1-9) as complete
+  - Verified removal of all old artifacts from previous implementation
+
+  The daily command now:
+  - Supports multiple date formats (today, yesterday, -N, YYYY-MM-DD)
+  - Generates numbered files when duplicates exist
+  - Uses GitHub Search API efficiently (single API call)
+  - Outputs structured data for Claude analysis
+
+  All planned functionality has been implemented and tested successfully.
+
+  🤖 Generated with Claude Code
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  CLAUDE.md — +7 / -0 (7 total)
+```diff
+@@ -182,6 +182,7 @@ The `.ai-orchestration/` directory contains files for tracking tooling developme
+   - `frontmatter-validation.sh`: Validates all content has proper frontmatter
+   - `run-content-update.sh`: Handles content update workflow
+   - `run-deployment.sh`: Handles deployment workflow
++  - `daily.sh`: Generates daily development logs from GitHub commits
+
+ ### Future Enhancements
+
+@@ -202,6 +203,12 @@ git add . && git commit -m "Your message" && git push
+ # Rebuild website (includes validation + deployment)
+ /rebuild-website
+
++# Generate daily development log
++/daily                    # Today's commits
++/daily yesterday         # Yesterday's commits
++/daily -3               # 3 days ago
++/daily 2025-09-20      # Specific date
++
+ # Run individual workflow components (if needed)
+ .claude/scripts/run-content-update.sh
+ .claude/scripts/run-deployment.sh
+```
+
+  plan-refactor-daily-command.md — +10 / -10 (20 total)
+```diff
+@@ -58,17 +58,17 @@ Refactor the `/daily` command from a complex multi-script system to a single, st
+ - [x] Add Claude analysis instructions from spec
+ - [x] Test command file with Claude
+
+-### 8. Integration testing
+-- [ ] Test /daily with no arguments (today)
+-- [ ] Test /daily yesterday
+-- [ ] Test /daily -3 (3 days ago)
+-- [ ] Test /daily 2025-09-20 (specific date)
+-- [ ] Test file numbering by running command twice
++### 8. Integration testing ✓
++- [x] Test /daily with no arguments (today)
++- [x] Test /daily yesterday
++- [x] Test /daily -3 (3 days ago)
++- [x] Test /daily 2025-09-20 (specific date)
++- [x] Test file numbering by running command twice
+
+-### 9. Documentation and cleanup
+-- [ ] Update CLAUDE.md with new daily command info
+-- [ ] Verify all old artifacts are removed
+-- [ ] Final test of complete workflow
++### 9. Documentation and cleanup ✓
++- [x] Update CLAUDE.md with new daily command info
++- [x] Verify all old artifacts are removed
++- [x] Final test of complete workflow
+
+ ## Implementation Notes
+
+```
+
+
+Repository: meaningfool/meaningfool-writing
+Commit: [a216324bc499f47217e93fd6358e286901ba9f18] Improve daily.md command instructions
+Description:
+  - Add numbered step-by-step instructions for clarity
+  - Specify exact usage of OUTPUT_FILE and TARGET_DATE variables
+  - Rename sections to ANALYSIS and RAW COMMITS for better structure
+  - Make instructions more explicit about frontmatter creation
+
+  🤖 Generated with Claude Code
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+
+Repository: meaningfool/meaningfool-writing
+Commit: [097736953fe9a2fb8678c2d185376ba8cf46dbaa] Create daily.md command file for /daily slash command
+Description:
+  - Add daily.md command file with proper tool permissions (Write, Bash)
+  - Include script execution directive for daily.sh with argument passing
+  - Add comprehensive Claude analysis instructions focusing on technical challenges, new technologies, and AI process improvements
+  - Structure command file with clear Instructions and Retrieved commits sections
+  - Update plan to mark step 7 as completed
+
+  LEARNINGS:
+  - GitHub Search API only indexes default branches (no feature branch commits)
+  - No single API endpoint retrieves all commits across all branches by date
+  - Events API limited to 30 days/300 events, not suitable for historical data
+  - Full iteration (repos→branches→commits) would be slow and hit rate limits
+  - Current approach is optimal for daily log use case
+
+  Details: https://chatgpt.com/share/68d593f0-a81c-8010-833a-d1a7eaccebd7
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  plan-refactor-daily-command.md — +5 / -5 (10 total)
+```diff
+@@ -52,11 +52,11 @@ Refactor the `/daily` command from a complex multi-script system to a single, st
+ - [x] Output all data in format for Claude
+ - [x] Test main function with various arguments
+
+-### 7. Create daily.md command file
+-- [ ] Set allowed-tools to Write only
+-- [ ] Add script execution directive
+-- [ ] Add Claude analysis instructions from spec
+-- [ ] Test command file with Claude
++### 7. Create daily.md command file ✓
++- [x] Set allowed-tools to Write only
++- [x] Add script execution directive
++- [x] Add Claude analysis instructions from spec
++- [x] Test command file with Claude
+
+ ### 8. Integration testing
+ - [ ] Test /daily with no arguments (today)
+```
+
+
+Repository: meaningfool/meaningfool-writing
+Commit: [9ffe13a02b127a10b6472347c5297e315bbed428] Complete main orchestration function for daily script
+Description:
+  - Implement complete main() function with proper argument parsing
+  - Add comprehensive error handling and validation flow
+  - Integrate all existing functions (validate_date, get_time_range, check_output_file, fetch_commits)
+  - Output clean data format for Claude with proper stderr/stdout separation
+  - Test with various input scenarios (no args, yesterday, relative dates, specific dates, invalid dates)
+  - Update plan to mark step 6 as completed
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  plan-refactor-daily-command.md — +8 / -8 (16 total)
+```diff
+@@ -43,14 +43,14 @@ Refactor the `/daily` command from a complex multi-script system to a single, st
+ - [x] Test fetch_commits with date having no commits
+ - [x] Test fetch_commits API error handling
+
+-### 6. Implement main orchestration function
+-- [ ] Parse command line arguments
+-- [ ] Call validate_date and handle errors
+-- [ ] Call get_time_range to get boundaries
+-- [ ] Call check_output_file to get filename
+-- [ ] Call fetch_commits and output metadata
+-- [ ] Output all data in format for Claude
+-- [ ] Test main function with various arguments
++### 6. Implement main orchestration function ✓
++- [x] Parse command line arguments
++- [x] Call validate_date and handle errors
++- [x] Call get_time_range to get boundaries
++- [x] Call check_output_file to get filename
++- [x] Call fetch_commits and output metadata
++- [x] Output all data in format for Claude
++- [x] Test main function with various arguments
+
+ ### 7. Create daily.md command file
+ - [ ] Set allowed-tools to Write only
+```
+
+
+Repository: meaningfool/meaningfool-writing
+Commit: [f7a3fc541248d392d2d501bf9964836453162af4] Implement complete fetch_commits function with GitHub Search API
+Description:
+  - Use GitHub Search API to find commits by author on target date
+  - Group commits by repository using temporary files
+  - Extract commit SHA, message, and file list for each commit
+  - Format output according to spec (Repository/Commit/Files structure)
+  - Add comprehensive error handling for API failures and rate limits
+  - Support multiple repositories and multiple commits per day
+  - Handle edge cases (no commits found, API errors)
+  - Update plan to mark fetch_commits function as complete
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  plan-refactor-daily-command.md — +9 / -9 (18 total)
+```diff
+@@ -33,15 +33,15 @@ Refactor the `/daily` command from a complex multi-script system to a single, st
+ - [x] Test check_output_file with one existing file
+ - [x] Test check_output_file with multiple numbered files
+
+-### 5. Implement fetch_commits function
+-- [ ] Use GitHub Search API to find all commits on target date
+-- [ ] Group commits by repository from search results
+-- [ ] Extract commit SHA, message, and file list for each commit
+-- [ ] Format output with proper spacing and structure
+-- [ ] Add error handling for API failures and rate limits
+-- [ ] Test fetch_commits with date having multiple repos
+-- [ ] Test fetch_commits with date having no commits
+-- [ ] Test fetch_commits API error handling
++### 5. Implement fetch_commits function ✓
++- [x] Use GitHub Search API to find all commits on target date
++- [x] Group commits by repository from search results
++- [x] Extract commit SHA, message, and file list for each commit
++- [x] Format output with proper spacing and structure
++- [x] Add error handling for API failures and rate limits
++- [x] Test fetch_commits with date having multiple repos
++- [x] Test fetch_commits with date having no commits
++- [x] Test fetch_commits API error handling
+
+ ### 6. Implement main orchestration function
+ - [ ] Parse command line arguments
+```
+
+
+Repository: meaningfool/meaningfool-writing
+Commit: [502c007f56ab7e2e181c336a31b3de23099429da] Update daily command plan with better GitHub API approach
+Description:
+  Change fetch_commits strategy from repository-first to commit-first approach:
+  - Use GitHub Search API to find commits by date directly
+  - Group results by repository instead of checking each repo individually
+  - More efficient single API call vs dozens of individual repo checks
+
+  LEARNINGS:
+  - GitHub doesn't provide single API to "find all repos with commits on date X"
+  - Two approaches exist: repository-first vs commit-first
+  - Repository-first: List all repos, check each for commits (inefficient, many API calls)
+  - Commit-first: Search commits by date, group by repo (efficient, single API call)
+  - GitHub Search API supports: gh api "/search/commits?q=author:USERNAME+committer-date:YYYY-MM-DD"
+  - Search-first approach benefits: one API call, only active repos, faster, avoids rate limits
+  - Official docs confirm both valid but search-first preferred for efficiency
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  plan-refactor-daily-command.md — +3 / -3 (6 total)
+```diff
+@@ -34,9 +34,9 @@ Refactor the `/daily` command from a complex multi-script system to a single, st
+ - [x] Test check_output_file with multiple numbered files
+
+ ### 5. Implement fetch_commits function
+-- [ ] List all repositories with activity on target date
+-- [ ] Fetch commits for each repository in date range
+-- [ ] Extract commit SHA, message, and file list
++- [ ] Use GitHub Search API to find all commits on target date
++- [ ] Group commits by repository from search results
++- [ ] Extract commit SHA, message, and file list for each commit
+ - [ ] Format output with proper spacing and structure
+ - [ ] Add error handling for API failures and rate limits
+ - [ ] Test fetch_commits with date having multiple repos
+```
+
+
+Repository: meaningfool/meaningfool-writing
+Commit: [895331930e06c2610f2b34443cbcbce00e2d2112] Implement check_output_file function with automatic numbering
+Description:
+  - Add check_output_file function to handle daily log file naming
+  - Check for base filename in daily-logs folder (not root)
+  - Implement automatic numbering for duplicate files
+  - Support format: daily-logs/YYYY-MM-DD-daily-log.md, then (2), (3), etc.
+  - Test all scenarios: no file, one existing file, multiple numbered files
+  - Update plan to mark check_output_file tasks as completed
+
+  The function ensures unique filenames when running daily command multiple
+  times for the same date without overwriting existing logs.
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  plan-refactor-daily-command.md — +7 / -7 (14 total)
+```diff
+@@ -25,13 +25,13 @@ Refactor the `/daily` command from a complex multi-script system to a single, st
+ - [x] Format times in ISO format with timezone offset
+ - [x] Test get_time_range with different dates and timezones
+
+-### 4. Implement check_output_file function
+-- [ ] Check if base filename exists (YYYY-MM-DD-daily-log.md)
+-- [ ] Find highest numbered variant if file exists
+-- [ ] Return next available filename with proper numbering
+-- [ ] Test check_output_file with no existing file
+-- [ ] Test check_output_file with one existing file
+-- [ ] Test check_output_file with multiple numbered files
++### 4. Implement check_output_file function ✓
++- [x] Check if base filename exists (YYYY-MM-DD-daily-log.md)
++- [x] Find highest numbered variant if file exists
++- [x] Return next available filename with proper numbering
++- [x] Test check_output_file with no existing file
++- [x] Test check_output_file with one existing file
++- [x] Test check_output_file with multiple numbered files
+
+ ### 5. Implement fetch_commits function
+ - [ ] List all repositories with activity on target date
+```
+
+
+Repository: meaningfool/meaningfool-writing
+Commit: [b22b7348d750ab4651f8f1e96460663b7fec17b9] Implement get_time_range function for local timezone handling
+Description:
+  - Add get_time_range function to convert YYYY-MM-DD dates to ISO time ranges
+  - Calculate start time (00:00:00) and end time (23:59:59) in local timezone
+  - Format times with proper timezone offset (+02:00)
+  - Test function with different dates and eval usage
+  - Update plan to mark get_time_range tasks as completed
+
+  The function outputs START_TIME and END_TIME variables that can be used
+  with eval to set environment variables for GitHub API calls.
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  plan-refactor-daily-command.md — +13 / -13 (26 total)
+```diff
+@@ -10,20 +10,20 @@ Refactor the `/daily` command from a complex multi-script system to a single, st
+ - [x] Remove old daily.md command file
+ - [x] Clean up .daily working directory
+
+-### 2. Create script structure and validate_date function
+-- [ ] Create daily.sh with basic structure and function stubs
+-- [ ] Implement validate_date for empty input (default to today)
+-- [ ] Implement validate_date for 'yesterday' keyword
+-- [ ] Implement validate_date for relative dates (-N format)
+-- [ ] Implement validate_date for YYYY-MM-DD format
+-- [ ] Add error handling for invalid date formats
+-- [ ] Test validate_date with all input types
++### 2. Create script structure and validate_date function ✓
++- [x] Create daily.sh with basic structure and function stubs
++- [x] Implement validate_date for empty input (default to today)
++- [x] Implement validate_date for 'yesterday' keyword
++- [x] Implement validate_date for relative dates (-N format)
++- [x] Implement validate_date for YYYY-MM-DD format
++- [x] Add error handling for invalid date formats
++- [x] Test validate_date with all input types
+
+-### 3. Implement get_time_range function
+-- [ ] Calculate start time (00:00:00) in local timezone
+-- [ ] Calculate end time (23:59:59) in local timezone
+-- [ ] Format times in ISO format with timezone offset
+-- [ ] Test get_time_range with different dates and timezones
++### 3. Implement get_time_range function ✓
++- [x] Calculate start time (00:00:00) in local timezone
++- [x] Calculate end time (23:59:59) in local timezone
++- [x] Format times in ISO format with timezone offset
++- [x] Test get_time_range with different dates and timezones
+
+ ### 4. Implement check_output_file function
+ - [ ] Check if base filename exists (YYYY-MM-DD-daily-log.md)
+```
+
+
+Repository: meaningfool/meaningfool-writing
+Commit: [ba77ea025c0d6100b94fbdf697ecb8551d17d3ae] Implement daily.sh with validate_date function
+Description:
+  - Create new single-script daily.sh with function stubs
+  - Implement complete validate_date function:
+    - Empty input defaults to today
+    - Support for 'yesterday' keyword
+    - Support for relative dates (-N format for N days ago)
+    - Support for YYYY-MM-DD format with validation
+    - Error handling for invalid date formats
+  - Test all date input formats and edge cases
+  - Update plan to mark validate_date tasks as completed
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  plan-refactor-daily-command.md — +4 / -4 (8 total)
+```diff
+@@ -5,10 +5,10 @@ Refactor the `/daily` command from a complex multi-script system to a single, st
+
+ ## Todo List
+
+-### 1. Clean up old implementation
+-- [ ] Remove old script files (fetch-commits.sh, prepare-analysis.sh, utils.sh)
+-- [ ] Remove old daily.md command file
+-- [ ] Clean up .daily working directory
++### 1. Clean up old implementation ✓
++- [x] Remove old script files (fetch-commits.sh, prepare-analysis.sh, utils.sh)
++- [x] Remove old daily.md command file
++- [x] Clean up .daily working directory
+
+ ### 2. Create script structure and validate_date function
+ - [ ] Create daily.sh with basic structure and function stubs
+```
+
+
+Repository: meaningfool/meaningfool-writing
+Commit: [d518045b20c89d9855e58bed649f409ceee81044] Remove old daily command implementation
+Description:
+  Clean up all files from the complex multi-script daily command:
+  - Remove fetch-commits.sh, prepare-analysis.sh, utils.sh scripts
+  - Remove old daily.md command file
+  - Delete .daily working directory (removed separately)
+
+  Preparing for simplified single-script implementation.
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+
+Repository: meaningfool/meaningfool-writing
+Commit: [f98c384f961f55d9096074f9d7db0eef022b5801] Add refactoring plan and spec for daily command simplification
+Description:
+  - Add spec-refactor-daily-command.md with detailed requirements
+  - Add plan-refactor-daily-command.md with implementation tasks
+  - Refactor /daily from complex multi-script system to single streamlined script
+  - Include grouped tasks for each function with testing steps
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  plan-refactor-daily-command.md — +95 / -0 (95 total)
+```diff
+@@ -0,0 +1,95 @@
++# Plan: Refactor Daily Command
++
++## Overview
++Refactor the `/daily` command from a complex multi-script system to a single, streamlined script that generates development logs by fetching and analyzing GitHub commits.
++
++## Todo List
++
++### 1. Clean up old implementation
++- [ ] Remove old script files (fetch-commits.sh, prepare-analysis.sh, utils.sh)
++- [ ] Remove old daily.md command file
++- [ ] Clean up .daily working directory
++
++### 2. Create script structure and validate_date function
++- [ ] Create daily.sh with basic structure and function stubs
++- [ ] Implement validate_date for empty input (default to today)
++- [ ] Implement validate_date for 'yesterday' keyword
++- [ ] Implement validate_date for relative dates (-N format)
++- [ ] Implement validate_date for YYYY-MM-DD format
++- [ ] Add error handling for invalid date formats
++- [ ] Test validate_date with all input types
++
++### 3. Implement get_time_range function
++- [ ] Calculate start time (00:00:00) in local timezone
++- [ ] Calculate end time (23:59:59) in local timezone
++- [ ] Format times in ISO format with timezone offset
++- [ ] Test get_time_range with different dates and timezones
++
++### 4. Implement check_output_file function
++- [ ] Check if base filename exists (YYYY-MM-DD-daily-log.md)
++- [ ] Find highest numbered variant if file exists
++- [ ] Return next available filename with proper numbering
++- [ ] Test check_output_file with no existing file
++- [ ] Test check_output_file with one existing file
++- [ ] Test check_output_file with multiple numbered files
++
++### 5. Implement fetch_commits function
++- [ ] List all repositories with activity on target date
++- [ ] Fetch commits for each repository in date range
++- [ ] Extract commit SHA, message, and file list
++- [ ] Format output with proper spacing and structure
++- [ ] Add error handling for API failures and rate limits
++- [ ] Test fetch_commits with date having multiple repos
++- [ ] Test fetch_commits with date having no commits
++- [ ] Test fetch_commits API error handling
++
++### 6. Implement main orchestration function
++- [ ] Parse command line arguments
++- [ ] Call validate_date and handle errors
++- [ ] Call get_time_range to get boundaries
++- [ ] Call check_output_file to get filename
++- [ ] Call fetch_commits and output metadata
++- [ ] Output all data in format for Claude
++- [ ] Test main function with various arguments
++
++### 7. Create daily.md command file
++- [ ] Set allowed-tools to Write only
++- [ ] Add script execution directive
++- [ ] Add Claude analysis instructions from spec
++- [ ] Test command file with Claude
++
++### 8. Integration testing
++- [ ] Test /daily with no arguments (today)
++- [ ] Test /daily yesterday
++- [ ] Test /daily -3 (3 days ago)
++- [ ] Test /daily 2025-09-20 (specific date)
++- [ ] Test file numbering by running command twice
++
++### 9. Documentation and cleanup
++- [ ] Update CLAUDE.md with new daily command info
++- [ ] Verify all old artifacts are removed
++- [ ] Final test of complete workflow
++
++## Implementation Notes
++
++### Key Changes from Current Implementation
++- **Single script** instead of multiple scripts (fetch-commits.sh, prepare-analysis.sh, utils.sh)
++- **No intermediate files** - data flows directly from script to Claude
++- **No caching** - fresh execution every time
++- **Local timezone** instead of UTC for more intuitive date handling
++- **Simplified file naming** - automatic numbering for duplicates
++- **Direct output** - script outputs all data for Claude in one execution
++
++### Technical Details
++- Use GitHub CLI (`gh`) for all API calls
++- Handle rate limiting gracefully with error messages
++- Output format optimized for Claude's analysis
++- All functions contained in single `daily.sh` file
++- Command file (`daily.md`) contains Claude's analysis instructions
++
++### Expected Outcomes
++- Simpler, more maintainable codebase
++- Faster execution (no intermediate file I/O)
++- Easier debugging (single script to troubleshoot)
++- More reliable (fewer moving parts)
++- Better user experience (clearer error messages)
+\ No newline at end of file
+```
+
+  spec-refactor-daily-command.md — +152 / -0 (152 total)
+```diff
+@@ -0,0 +1,152 @@
++# Specification: Refactored Daily Command
++
++## Overview
++Simplify the `/daily` command to generate development logs by fetching GitHub commits for a specified date and having Claude analyze them for insights.
++
++## Requirements
++
++### Input
++- Date parameter that can take forms:
++  - Empty (defaults to today)
++  - `yesterday`
++  - `-N` (N days ago, e.g., `-3`)
++  - `YYYY-MM-DD` (specific date)
++
++### Output
++- Creates a file in root directory: `YYYY-MM-DD-daily-log.md`
++- If file exists, creates numbered versions: `YYYY-MM-DD-daily-log(2).md`, `YYYY-MM-DD-daily-log(3).md`, etc.
++- File contains Claude's analysis of the day's commits
++
++### Core Functionality
++1. Validate date parameter
++2. Check for existing output file and determine filename
++3. Fetch all commits from all repos for TARGET_DATE (local timezone)
++4. Pass commit data to Claude for analysis
++5. Claude writes insights to output file
++
++## Architecture
++
++### Single Script Approach
++- One script file: `.claude/scripts/daily.sh`
++- Contains functions that can be called internally
++- Single execution outputs all data needed for Claude
++
++### Script Structure (`daily.sh`)
++
++```bash
++#!/usr/bin/env bash
++
++validate_date() {
++    # Input: date argument (empty, "yesterday", "-3", "2025-09-11", etc.)
++    # Output: YYYY-MM-DD format
++    # Uses local timezone
++}
++
++get_time_range() {
++    # Input: validated date in YYYY-MM-DD
++    # Output: START_TIME and END_TIME in ISO format with local timezone
++    # Example: 2025-09-25T00:00:00-07:00 2025-09-25T23:59:59-07:00
++}
++
++check_output_file() {
++    # Input: target date YYYY-MM-DD
++    # Output: available filename
++    # Logic: Check for existing files, find highest (N), return next available
++    # Examples:
++    #   - No file exists → 2025-09-25-daily-log.md
++    #   - File exists → 2025-09-25-daily-log(2).md
++    #   - (2) exists → 2025-09-25-daily-log(3).md
++}
++
++fetch_commits() {
++    # Input: target_date, start_time, end_time
++    # Output: formatted commit data
++    # Uses: gh api to fetch commits from all repos with activity
++    # Filters: only repos with commits on target date
++    # Format:
++    #   Repository: user/repo-name
++    #   Commit: [sha] commit message
++    #   Files: file1.js, file2.md
++    #   [blank line between repos]
++}
++
++main() {
++    # Orchestrates all functions
++    # Outputs metadata and commit data for Claude
++}
++```
++
++### Command File (`daily.md`)
++
++```markdown
++---
++allowed-tools: Write
++description: Generate daily development log from GitHub commits
++---
++
++# Daily Development Log Generation
++
++!.claude/scripts/daily.sh "$1"
++
++[Above script outputs:]
++- OUTPUT_FILE=YYYY-MM-DD-daily-log.md (or numbered variant)
++- TARGET_DATE=YYYY-MM-DD
++- Formatted commit data
++
++---
++
++## Analysis Instructions
++
++For each repository with activity, I'll analyze the data and extract from the data meaningful signals focusing on:
++- **Technical challenges solved** - what specific problems were encountered, how they were debugged, and what solutions were implemented. For this look specifically at code file diffs and at changes in plans that are reflected in .md files.
++- **New technologies, specific findings about how their idiosyncracies** - trials and mistakes lead, and research, lead to discoveries about why things won't work or work only in certain ways. This is useful knowledge that we want to surface. For that look in particular at .md files which un packs our thinking, our plans, what we tried, and our research.
++- **AI process improvements or setbacks** - the AI-assisted development process is harnessed using .md files. Some of them contain general instructions (claude.md), some capture automation processes (in .claude). And some others (those that contains plans, or logs of what happened for example) support the AI-assisted development process to store short-term memories mostly and keep track of what was done and what needs to be done. For these last ones, it's not so much the exact content than how they are used to support the development process that is interesting. So analyze all those files to identify if and how we changed the process.
++
++Each extracted item is formatted a new bullet point. And for each extracted item provide some details in the form of up to 3 sub-bullet points each of one sentence maximum.
++
++It should look like so:
++- **Item title A**:
++  - Description sentence 1
++  - Description sentence 2
++- **Item title B**:
++  - Description sentence 1
++  - Description sentence 2
++  - Description sentence 3
++- An so on...
++
++[Claude processes commits and writes analysis to OUTPUT_FILE]
++```
++
++## Data Flow
++
++1. User runs `/daily` or `/daily yesterday` or `/daily -3` etc.
++2. `daily.sh` executes with the argument
++3. Script validates date → determines time range → checks output file → fetches commits
++4. All data outputs to stdout and becomes part of Claude's prompt
++5. Claude analyzes commits according to instructions
++6. Claude writes formatted analysis to the output file
++
++## Key Differences from Current Implementation
++
++### Removed
++- Multiple script files (fetch-commits.sh, prepare-analysis.sh, utils.sh)
++- Session files and environment variables
++- Intermediate data storage in `.daily/` directory
++- Caching and data reuse logic
++- Complex phase-based execution
++- File patches and detailed diffs (keeping just commit messages and file names)
++
++### Simplified
++- Single script execution
++- No intermediate files
++- Direct output to Claude's context
++- Local timezone instead of UTC
++- Straightforward file numbering for duplicates
++
++## Implementation Notes
++
++- Use GitHub CLI (`gh`) for API calls
++- Handle rate limiting gracefully
++- Include only repos with commits on target date
++- Keep output format simple and parseable
++- Error handling for invalid dates or API failures
+\ No newline at end of file
+```
+
+
+Repository: meaningfool/meaningfool.github.io
+Commit: [92e704339684e179db573f40251bdeadb8151704] Update site styling and content
+Description:
+  - Improve layout spacing and typography
+  - Update about page content structure
+  - Update homepage styling
+  - Update content submodule with latest articles
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>

--- a/daily-logs/2025-09-25-daily-log.md
+++ b/daily-logs/2025-09-25-daily-log.md
@@ -1,0 +1,730 @@
+---
+title: "Activity Log - 2025-09-25"
+date: 2025-09-25
+---
+
+## ANALYSIS
+
+- **Daily command refactoring completion**:
+  - Successfully transitioned from complex multi-script system to single streamlined script
+  - All 9 planned implementation phases completed with comprehensive testing
+  - New architecture supports multiple date formats and automatic file numbering
+
+- **GitHub API optimization discovery**:
+  - Learned GitHub Search API only indexes default branches, not feature branches
+  - Discovered commit-first approach (search by date) is more efficient than repository-first approach
+  - Found Events API has 30-day limit unsuitable for historical data retrieval
+
+- **AI process enhancement through structured planning**:
+  - Used detailed plan files (plan-refactor-daily-command.md) to track 95 specific tasks across 9 phases
+  - Implemented systematic checkbox-based progress tracking for complex refactoring
+  - Plan file served as both roadmap and documentation of implementation decisions
+
+- **Command system architecture simplification**:
+  - Eliminated intermediate files and caching for more reliable execution
+  - Moved from UTC to local timezone for intuitive date handling
+  - Created single daily.sh script replacing fetch-commits.sh, prepare-analysis.sh, and utils.sh
+
+- **Documentation integration workflow**:
+  - Updated CLAUDE.md with comprehensive daily command usage examples
+  - Added daily.sh script to architecture overview section
+  - Created structured command summary section for quick reference
+
+## RAW COMMITS
+
+Repository: meaningfool/meaningfool-writing
+Commit: [a08b941c0391fa908413a7d862706827d1a91a56] Complete daily command refactoring implementation
+Description:
+  Successfully refactored /daily command from multi-script system to single streamlined script.
+
+  Changes:
+  - Completed all integration tests for various date formats
+  - Updated CLAUDE.md with /daily command documentation and examples
+  - Marked all plan items (1-9) as complete
+  - Verified removal of all old artifacts from previous implementation
+
+  The daily command now:
+  - Supports multiple date formats (today, yesterday, -N, YYYY-MM-DD)
+  - Generates numbered files when duplicates exist
+  - Uses GitHub Search API efficiently (single API call)
+  - Outputs structured data for Claude analysis
+
+  All planned functionality has been implemented and tested successfully.
+
+  🤖 Generated with Claude Code
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  CLAUDE.md — +7 / -0 (7 total)
+```diff
+@@ -182,6 +182,7 @@ The `.ai-orchestration/` directory contains files for tracking tooling developme
+   - `frontmatter-validation.sh`: Validates all content has proper frontmatter
+   - `run-content-update.sh`: Handles content update workflow
+   - `run-deployment.sh`: Handles deployment workflow
++  - `daily.sh`: Generates daily development logs from GitHub commits
+
+ ### Future Enhancements
+
+@@ -202,6 +203,12 @@ git add . && git commit -m "Your message" && git push
+ # Rebuild website (includes validation + deployment)
+ /rebuild-website
+
++# Generate daily development log
++/daily                    # Today's commits
++/daily yesterday         # Yesterday's commits
++/daily -3               # 3 days ago
++/daily 2025-09-20      # Specific date
++
+ # Run individual workflow components (if needed)
+ .claude/scripts/run-content-update.sh
+ .claude/scripts/run-deployment.sh
+```
+
+  plan-refactor-daily-command.md — +10 / -10 (20 total)
+```diff
+@@ -58,17 +58,17 @@ Refactor the `/daily` command from a complex multi-script system to a single, st
+ - [x] Add Claude analysis instructions from spec
+ - [x] Test command file with Claude
+
+-### 8. Integration testing
+-- [ ] Test /daily with no arguments (today)
+-- [ ] Test /daily yesterday
+-- [ ] Test /daily -3 (3 days ago)
+-- [ ] Test /daily 2025-09-20 (specific date)
+-- [ ] Test file numbering by running command twice
++### 8. Integration testing ✓
++- [x] Test /daily with no arguments (today)
++- [x] Test /daily yesterday
++- [x] Test /daily -3 (3 days ago)
++- [x] Test /daily 2025-09-20 (specific date)
++- [x] Test file numbering by running command twice
+
+-### 9. Documentation and cleanup
+-- [ ] Update CLAUDE.md with new daily command info
+-- [ ] Verify all old artifacts are removed
+-- [ ] Final test of complete workflow
++### 9. Documentation and cleanup ✓
++- [x] Update CLAUDE.md with new daily command info
++- [x] Verify all old artifacts are removed
++- [x] Final test of complete workflow
+
+ ## Implementation Notes
+
+```
+
+
+Repository: meaningfool/meaningfool-writing
+Commit: [a216324bc499f47217e93fd6358e286901ba9f18] Improve daily.md command instructions
+Description:
+  - Add numbered step-by-step instructions for clarity
+  - Specify exact usage of OUTPUT_FILE and TARGET_DATE variables
+  - Rename sections to ANALYSIS and RAW COMMITS for better structure
+  - Make instructions more explicit about frontmatter creation
+
+  🤖 Generated with Claude Code
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+
+Repository: meaningfool/meaningfool-writing
+Commit: [097736953fe9a2fb8678c2d185376ba8cf46dbaa] Create daily.md command file for /daily slash command
+Description:
+  - Add daily.md command file with proper tool permissions (Write, Bash)
+  - Include script execution directive for daily.sh with argument passing
+  - Add comprehensive Claude analysis instructions focusing on technical challenges, new technologies, and AI process improvements
+  - Structure command file with clear Instructions and Retrieved commits sections
+  - Update plan to mark step 7 as completed
+
+  LEARNINGS:
+  - GitHub Search API only indexes default branches (no feature branch commits)
+  - No single API endpoint retrieves all commits across all branches by date
+  - Events API limited to 30 days/300 events, not suitable for historical data
+  - Full iteration (repos→branches→commits) would be slow and hit rate limits
+  - Current approach is optimal for daily log use case
+
+  Details: https://chatgpt.com/share/68d593f0-a81c-8010-833a-d1a7eaccebd7
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  plan-refactor-daily-command.md — +5 / -5 (10 total)
+```diff
+@@ -52,11 +52,11 @@ Refactor the `/daily` command from a complex multi-script system to a single, st
+ - [x] Output all data in format for Claude
+ - [x] Test main function with various arguments
+
+-### 7. Create daily.md command file
+-- [ ] Set allowed-tools to Write only
+-- [ ] Add script execution directive
+-- [ ] Add Claude analysis instructions from spec
+-- [ ] Test command file with Claude
++### 7. Create daily.md command file ✓
++- [x] Set allowed-tools to Write only
++- [x] Add script execution directive
++- [x] Add Claude analysis instructions from spec
++- [x] Test command file with Claude
+
+ ### 8. Integration testing
+ - [ ] Test /daily with no arguments (today)
+```
+
+
+Repository: meaningfool/meaningfool-writing
+Commit: [9ffe13a02b127a10b6472347c5297e315bbed428] Complete main orchestration function for daily script
+Description:
+  - Implement complete main() function with proper argument parsing
+  - Add comprehensive error handling and validation flow
+  - Integrate all existing functions (validate_date, get_time_range, check_output_file, fetch_commits)
+  - Output clean data format for Claude with proper stderr/stdout separation
+  - Test with various input scenarios (no args, yesterday, relative dates, specific dates, invalid dates)
+  - Update plan to mark step 6 as completed
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  plan-refactor-daily-command.md — +8 / -8 (16 total)
+```diff
+@@ -43,14 +43,14 @@ Refactor the `/daily` command from a complex multi-script system to a single, st
+ - [x] Test fetch_commits with date having no commits
+ - [x] Test fetch_commits API error handling
+
+-### 6. Implement main orchestration function
+-- [ ] Parse command line arguments
+-- [ ] Call validate_date and handle errors
+-- [ ] Call get_time_range to get boundaries
+-- [ ] Call check_output_file to get filename
+-- [ ] Call fetch_commits and output metadata
+-- [ ] Output all data in format for Claude
+-- [ ] Test main function with various arguments
++### 6. Implement main orchestration function ✓
++- [x] Parse command line arguments
++- [x] Call validate_date and handle errors
++- [x] Call get_time_range to get boundaries
++- [x] Call check_output_file to get filename
++- [x] Call fetch_commits and output metadata
++- [x] Output all data in format for Claude
++- [x] Test main function with various arguments
+
+ ### 7. Create daily.md command file
+ - [ ] Set allowed-tools to Write only
+```
+
+
+Repository: meaningfool/meaningfool-writing
+Commit: [f7a3fc541248d392d2d501bf9964836453162af4] Implement complete fetch_commits function with GitHub Search API
+Description:
+  - Use GitHub Search API to find commits by author on target date
+  - Group commits by repository using temporary files
+  - Extract commit SHA, message, and file list for each commit
+  - Format output according to spec (Repository/Commit/Files structure)
+  - Add comprehensive error handling for API failures and rate limits
+  - Support multiple repositories and multiple commits per day
+  - Handle edge cases (no commits found, API errors)
+  - Update plan to mark fetch_commits function as complete
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  plan-refactor-daily-command.md — +9 / -9 (18 total)
+```diff
+@@ -33,15 +33,15 @@ Refactor the `/daily` command from a complex multi-script system to a single, st
+ - [x] Test check_output_file with one existing file
+ - [x] Test check_output_file with multiple numbered files
+
+-### 5. Implement fetch_commits function
+-- [ ] Use GitHub Search API to find all commits on target date
+-- [ ] Group commits by repository from search results
+-- [ ] Extract commit SHA, message, and file list for each commit
+-- [ ] Format output with proper spacing and structure
+-- [ ] Add error handling for API failures and rate limits
+-- [ ] Test fetch_commits with date having multiple repos
+-- [ ] Test fetch_commits with date having no commits
+-- [ ] Test fetch_commits API error handling
++### 5. Implement fetch_commits function ✓
++- [x] Use GitHub Search API to find all commits on target date
++- [x] Group commits by repository from search results
++- [x] Extract commit SHA, message, and file list for each commit
++- [x] Format output with proper spacing and structure
++- [x] Add error handling for API failures and rate limits
++- [x] Test fetch_commits with date having multiple repos
++- [x] Test fetch_commits with date having no commits
++- [x] Test fetch_commits API error handling
+
+ ### 6. Implement main orchestration function
+ - [ ] Parse command line arguments
+```
+
+
+Repository: meaningfool/meaningfool-writing
+Commit: [502c007f56ab7e2e181c336a31b3de23099429da] Update daily command plan with better GitHub API approach
+Description:
+  Change fetch_commits strategy from repository-first to commit-first approach:
+  - Use GitHub Search API to find commits by date directly
+  - Group results by repository instead of checking each repo individually
+  - More efficient single API call vs dozens of individual repo checks
+
+  LEARNINGS:
+  - GitHub doesn't provide single API to "find all repos with commits on date X"
+  - Two approaches exist: repository-first vs commit-first
+  - Repository-first: List all repos, check each for commits (inefficient, many API calls)
+  - Commit-first: Search commits by date, group by repo (efficient, single API call)
+  - GitHub Search API supports: gh api "/search/commits?q=author:USERNAME+committer-date:YYYY-MM-DD"
+  - Search-first approach benefits: one API call, only active repos, faster, avoids rate limits
+  - Official docs confirm both valid but search-first preferred for efficiency
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  plan-refactor-daily-command.md — +3 / -3 (6 total)
+```diff
+@@ -34,9 +34,9 @@ Refactor the `/daily` command from a complex multi-script system to a single, st
+ - [x] Test check_output_file with multiple numbered files
+
+ ### 5. Implement fetch_commits function
+-- [ ] List all repositories with activity on target date
+-- [ ] Fetch commits for each repository in date range
+-- [ ] Extract commit SHA, message, and file list
++- [ ] Use GitHub Search API to find all commits on target date
++- [ ] Group commits by repository from search results
++- [ ] Extract commit SHA, message, and file list for each commit
+ - [ ] Format output with proper spacing and structure
+ - [ ] Add error handling for API failures and rate limits
+ - [ ] Test fetch_commits with date having multiple repos
+```
+
+
+Repository: meaningfool/meaningfool-writing
+Commit: [895331930e06c2610f2b34443cbcbce00e2d2112] Implement check_output_file function with automatic numbering
+Description:
+  - Add check_output_file function to handle daily log file naming
+  - Check for base filename in daily-logs folder (not root)
+  - Implement automatic numbering for duplicate files
+  - Support format: daily-logs/YYYY-MM-DD-daily-log.md, then (2), (3), etc.
+  - Test all scenarios: no file, one existing file, multiple numbered files
+  - Update plan to mark check_output_file tasks as completed
+
+  The function ensures unique filenames when running daily command multiple
+  times for the same date without overwriting existing logs.
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  plan-refactor-daily-command.md — +7 / -7 (14 total)
+```diff
+@@ -25,13 +25,13 @@ Refactor the `/daily` command from a complex multi-script system to a single, st
+ - [x] Format times in ISO format with timezone offset
+ - [x] Test get_time_range with different dates and timezones
+
+-### 4. Implement check_output_file function
+-- [ ] Check if base filename exists (YYYY-MM-DD-daily-log.md)
+-- [ ] Find highest numbered variant if file exists
+-- [ ] Return next available filename with proper numbering
+-- [ ] Test check_output_file with no existing file
+-- [ ] Test check_output_file with one existing file
+-- [ ] Test check_output_file with multiple numbered files
++### 4. Implement check_output_file function ✓
++- [x] Check if base filename exists (YYYY-MM-DD-daily-log.md)
++- [x] Find highest numbered variant if file exists
++- [x] Return next available filename with proper numbering
++- [x] Test check_output_file with no existing file
++- [x] Test check_output_file with one existing file
++- [x] Test check_output_file with multiple numbered files
+
+ ### 5. Implement fetch_commits function
+ - [ ] List all repositories with activity on target date
+```
+
+
+Repository: meaningfool/meaningfool-writing
+Commit: [b22b7348d750ab4651f8f1e96460663b7fec17b9] Implement get_time_range function for local timezone handling
+Description:
+  - Add get_time_range function to convert YYYY-MM-DD dates to ISO time ranges
+  - Calculate start time (00:00:00) and end time (23:59:59) in local timezone
+  - Format times with proper timezone offset (+02:00)
+  - Test function with different dates and eval usage
+  - Update plan to mark get_time_range tasks as completed
+
+  The function outputs START_TIME and END_TIME variables that can be used
+  with eval to set environment variables for GitHub API calls.
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  plan-refactor-daily-command.md — +13 / -13 (26 total)
+```diff
+@@ -10,20 +10,20 @@ Refactor the `/daily` command from a complex multi-script system to a single, st
+ - [x] Remove old daily.md command file
+ - [x] Clean up .daily working directory
+
+-### 2. Create script structure and validate_date function
+-- [ ] Create daily.sh with basic structure and function stubs
+-- [ ] Implement validate_date for empty input (default to today)
+-- [ ] Implement validate_date for 'yesterday' keyword
+-- [ ] Implement validate_date for relative dates (-N format)
+-- [ ] Implement validate_date for YYYY-MM-DD format
+-- [ ] Add error handling for invalid date formats
+-- [ ] Test validate_date with all input types
++### 2. Create script structure and validate_date function ✓
++- [x] Create daily.sh with basic structure and function stubs
++- [x] Implement validate_date for empty input (default to today)
++- [x] Implement validate_date for 'yesterday' keyword
++- [x] Implement validate_date for relative dates (-N format)
++- [x] Implement validate_date for YYYY-MM-DD format
++- [x] Add error handling for invalid date formats
++- [x] Test validate_date with all input types
+
+-### 3. Implement get_time_range function
+-- [ ] Calculate start time (00:00:00) in local timezone
+-- [ ] Calculate end time (23:59:59) in local timezone
+-- [ ] Format times in ISO format with timezone offset
+-- [ ] Test get_time_range with different dates and timezones
++### 3. Implement get_time_range function ✓
++- [x] Calculate start time (00:00:00) in local timezone
++- [x] Calculate end time (23:59:59) in local timezone
++- [x] Format times in ISO format with timezone offset
++- [x] Test get_time_range with different dates and timezones
+
+ ### 4. Implement check_output_file function
+ - [ ] Check if base filename exists (YYYY-MM-DD-daily-log.md)
+```
+
+
+Repository: meaningfool/meaningfool-writing
+Commit: [ba77ea025c0d6100b94fbdf697ecb8551d17d3ae] Implement daily.sh with validate_date function
+Description:
+  - Create new single-script daily.sh with function stubs
+  - Implement complete validate_date function:
+    - Empty input defaults to today
+    - Support for 'yesterday' keyword
+    - Support for relative dates (-N format for N days ago)
+    - Support for YYYY-MM-DD format with validation
+    - Error handling for invalid date formats
+  - Test all date input formats and edge cases
+  - Update plan to mark validate_date tasks as completed
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  plan-refactor-daily-command.md — +4 / -4 (8 total)
+```diff
+@@ -5,10 +5,10 @@ Refactor the `/daily` command from a complex multi-script system to a single, st
+
+ ## Todo List
+
+-### 1. Clean up old implementation
+-- [ ] Remove old script files (fetch-commits.sh, prepare-analysis.sh, utils.sh)
+-- [ ] Remove old daily.md command file
+-- [ ] Clean up .daily working directory
++### 1. Clean up old implementation ✓
++- [x] Remove old script files (fetch-commits.sh, prepare-analysis.sh, utils.sh)
++- [x] Remove old daily.md command file
++- [x] Clean up .daily working directory
+
+ ### 2. Create script structure and validate_date function
+ - [ ] Create daily.sh with basic structure and function stubs
+```
+
+
+Repository: meaningfool/meaningfool-writing
+Commit: [d518045b20c89d9855e58bed649f409ceee81044] Remove old daily command implementation
+Description:
+  Clean up all files from the complex multi-script daily command:
+  - Remove fetch-commits.sh, prepare-analysis.sh, utils.sh scripts
+  - Remove old daily.md command file
+  - Delete .daily working directory (removed separately)
+
+  Preparing for simplified single-script implementation.
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+
+Repository: meaningfool/meaningfool-writing
+Commit: [f98c384f961f55d9096074f9d7db0eef022b5801] Add refactoring plan and spec for daily command simplification
+Description:
+  - Add spec-refactor-daily-command.md with detailed requirements
+  - Add plan-refactor-daily-command.md with implementation tasks
+  - Refactor /daily from complex multi-script system to single streamlined script
+  - Include grouped tasks for each function with testing steps
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+Tracked file changes:
+  plan-refactor-daily-command.md — +95 / -0 (95 total)
+```diff
+@@ -0,0 +1,95 @@
++# Plan: Refactor Daily Command
++
++## Overview
++Refactor the `/daily` command from a complex multi-script system to a single, streamlined script that generates development logs by fetching and analyzing GitHub commits.
++
++## Todo List
++
++### 1. Clean up old implementation
++- [ ] Remove old script files (fetch-commits.sh, prepare-analysis.sh, utils.sh)
++- [ ] Remove old daily.md command file
++- [ ] Clean up .daily working directory
++
++### 2. Create script structure and validate_date function
++- [ ] Create daily.sh with basic structure and function stubs
++- [ ] Implement validate_date for empty input (default to today)
++- [ ] Implement validate_date for 'yesterday' keyword
++- [ ] Implement validate_date for relative dates (-N format)
++- [ ] Implement validate_date for YYYY-MM-DD format
++- [ ] Add error handling for invalid date formats
++- [ ] Test validate_date with all input types
++
++### 3. Implement get_time_range function
++- [ ] Calculate start time (00:00:00) in local timezone
++- [ ] Calculate end time (23:59:59) in local timezone
++- [ ] Format times in ISO format with timezone offset
++- [ ] Test get_time_range with different dates and timezones
++
++### 4. Implement check_output_file function
++- [ ] Check if base filename exists (YYYY-MM-DD-daily-log.md)
++- [ ] Find highest numbered variant if file exists
++- [ ] Return next available filename with proper numbering
++- [ ] Test check_output_file with no existing file
++- [ ] Test check_output_file with one existing file
++- [ ] Test check_output_file with multiple numbered files
++
++### 5. Implement fetch_commits function
++- [ ] List all repositories with activity on target date
++- [ ] Fetch commits for each repository in date range
++- [ ] Extract commit SHA, message, and file list
++- [ ] Format output with proper spacing and structure
++- [ ] Add error handling for API failures and rate limits
++- [ ] Test fetch_commits with date having multiple repos
++- [ ] Test fetch_commits with date having no commits
++- [ ] Test fetch_commits API error handling
++
++### 6. Implement main orchestration function
++- [ ] Parse command line arguments
++- [ ] Call validate_date and handle errors
++- [ ] Call get_time_range to get boundaries
++- [ ] Call check_output_file to get filename
++- [ ] Call fetch_commits and output metadata
++- [ ] Output all data in format for Claude
++- [ ] Test main function with various arguments
++
++### 7. Create daily.md command file
++- [ ] Set allowed-tools to Write only
++- [ ] Add script execution directive
++- [ ] Add Claude analysis instructions from spec
++- [ ] Test command file with Claude
++
++### 8. Integration testing
++- [ ] Test /daily with no arguments (today)
++- [ ] Test /daily yesterday
++- [ ] Test /daily -3 (3 days ago)
++- [ ] Test /daily 2025-09-20 (specific date)
++- [ ] Test file numbering by running command twice
++
++### 9. Documentation and cleanup
++- [ ] Update CLAUDE.md with new daily command info
++- [ ] Verify all old artifacts are removed
++- [ ] Final test of complete workflow
++
++## Implementation Notes
++
++### Key Changes from Current Implementation
++- **Single script** instead of multiple scripts (fetch-commits.sh, prepare-analysis.sh, utils.sh)
++- **No intermediate files** - data flows directly from script to Claude
++- **No caching** - fresh execution every time
++- **Local timezone** instead of UTC for more intuitive date handling
++- **Simplified file naming** - automatic numbering for duplicates
++- **Direct output** - script outputs all data for Claude in one execution
++
++### Technical Details
++- Use GitHub CLI (`gh`) for all API calls
++- Handle rate limiting gracefully with error messages
++- Output format optimized for Claude's analysis
++- All functions contained in single `daily.sh` file
++- Command file (`daily.md`) contains Claude's analysis instructions
++
++### Expected Outcomes
++- Simpler, more maintainable codebase
++- Faster execution (no intermediate file I/O)
++- Easier debugging (single script to troubleshoot)
++- More reliable (fewer moving parts)
++- Better user experience (clearer error messages)
+\ No newline at end of file
+```
+
+  spec-refactor-daily-command.md — +152 / -0 (152 total)
+```diff
+@@ -0,0 +1,152 @@
++# Specification: Refactored Daily Command
++
++## Overview
++Simplify the `/daily` command to generate development logs by fetching GitHub commits for a specified date and having Claude analyze them for insights.
++
++## Requirements
++
++### Input
++- Date parameter that can take forms:
++  - Empty (defaults to today)
++  - `yesterday`
++  - `-N` (N days ago, e.g., `-3`)
++  - `YYYY-MM-DD` (specific date)
++
++### Output
++- Creates a file in root directory: `YYYY-MM-DD-daily-log.md`
++- If file exists, creates numbered versions: `YYYY-MM-DD-daily-log(2).md`, `YYYY-MM-DD-daily-log(3).md`, etc.
++- File contains Claude's analysis of the day's commits
++
++### Core Functionality
++1. Validate date parameter
++2. Check for existing output file and determine filename
++3. Fetch all commits from all repos for TARGET_DATE (local timezone)
++4. Pass commit data to Claude for analysis
++5. Claude writes insights to output file
++
++## Architecture
++
++### Single Script Approach
++- One script file: `.claude/scripts/daily.sh`
++- Contains functions that can be called internally
++- Single execution outputs all data needed for Claude
++
++### Script Structure (`daily.sh`)
++
++```bash
++#!/usr/bin/env bash
++
++validate_date() {
++    # Input: date argument (empty, "yesterday", "-3", "2025-09-11", etc.)
++    # Output: YYYY-MM-DD format
++    # Uses local timezone
++}
++
++get_time_range() {
++    # Input: validated date in YYYY-MM-DD
++    # Output: START_TIME and END_TIME in ISO format with local timezone
++    # Example: 2025-09-25T00:00:00-07:00 2025-09-25T23:59:59-07:00
++}
++
++check_output_file() {
++    # Input: target date YYYY-MM-DD
++    # Output: available filename
++    # Logic: Check for existing files, find highest (N), return next available
++    # Examples:
++    #   - No file exists → 2025-09-25-daily-log.md
++    #   - File exists → 2025-09-25-daily-log(2).md
++    #   - (2) exists → 2025-09-25-daily-log(3).md
++}
++
++fetch_commits() {
++    # Input: target_date, start_time, end_time
++    # Output: formatted commit data
++    # Uses: gh api to fetch commits from all repos with activity
++    # Filters: only repos with commits on target date
++    # Format:
++    #   Repository: user/repo-name
++    #   Commit: [sha] commit message
++    #   Files: file1.js, file2.md
++    #   [blank line between repos]
++}
++
++main() {
++    # Orchestrates all functions
++    # Outputs metadata and commit data for Claude
++}
++```
++
++### Command File (`daily.md`)
++
++```markdown
++---
++allowed-tools: Write
++description: Generate daily development log from GitHub commits
++---
++
++# Daily Development Log Generation
++
++!.claude/scripts/daily.sh "$1"
++
++[Above script outputs:]
++- OUTPUT_FILE=YYYY-MM-DD-daily-log.md (or numbered variant)
++- TARGET_DATE=YYYY-MM-DD
++- Formatted commit data
++
++---
++
++## Analysis Instructions
++
++For each repository with activity, I'll analyze the data and extract from the data meaningful signals focusing on:
++- **Technical challenges solved** - what specific problems were encountered, how they were debugged, and what solutions were implemented. For this look specifically at code file diffs and at changes in plans that are reflected in .md files.
++- **New technologies, specific findings about how their idiosyncracies** - trials and mistakes lead, and research, lead to discoveries about why things won't work or work only in certain ways. This is useful knowledge that we want to surface. For that look in particular at .md files which un packs our thinking, our plans, what we tried, and our research.
++- **AI process improvements or setbacks** - the AI-assisted development process is harnessed using .md files. Some of them contain general instructions (claude.md), some capture automation processes (in .claude). And some others (those that contains plans, or logs of what happened for example) support the AI-assisted development process to store short-term memories mostly and keep track of what was done and what needs to be done. For these last ones, it's not so much the exact content than how they are used to support the development process that is interesting. So analyze all those files to identify if and how we changed the process.
++
++Each extracted item is formatted a new bullet point. And for each extracted item provide some details in the form of up to 3 sub-bullet points each of one sentence maximum.
++
++It should look like so:
++- **Item title A**:
++  - Description sentence 1
++  - Description sentence 2
++- **Item title B**:
++  - Description sentence 1
++  - Description sentence 2
++  - Description sentence 3
++- An so on...
++
++[Claude processes commits and writes analysis to OUTPUT_FILE]
++```
++
++## Data Flow
++
++1. User runs `/daily` or `/daily yesterday` or `/daily -3` etc.
++2. `daily.sh` executes with the argument
++3. Script validates date → determines time range → checks output file → fetches commits
++4. All data outputs to stdout and becomes part of Claude's prompt
++5. Claude analyzes commits according to instructions
++6. Claude writes formatted analysis to the output file
++
++## Key Differences from Current Implementation
++
++### Removed
++- Multiple script files (fetch-commits.sh, prepare-analysis.sh, utils.sh)
++- Session files and environment variables
++- Intermediate data storage in `.daily/` directory
++- Caching and data reuse logic
++- Complex phase-based execution
++- File patches and detailed diffs (keeping just commit messages and file names)
++
++### Simplified
++- Single script execution
++- No intermediate files
++- Direct output to Claude's context
++- Local timezone instead of UTC
++- Straightforward file numbering for duplicates
++
++## Implementation Notes
++
++- Use GitHub CLI (`gh`) for API calls
++- Handle rate limiting gracefully
++- Include only repos with commits on target date
++- Keep output format simple and parseable
++- Error handling for invalid dates or API failures
+\ No newline at end of file
+```
+
+
+Repository: meaningfool/meaningfool.github.io
+Commit: [92e704339684e179db573f40251bdeadb8151704] Update site styling and content
+Description:
+  - Improve layout spacing and typography
+  - Update about page content structure
+  - Update homepage styling
+  - Update content submodule with latest articles
+
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>


### PR DESCRIPTION
## Summary
- fetch full commit file metadata from the GitHub API for use in the daily script
- filter tracked files to spec/plan markdown documents or claude.md
- output tracked file summaries with diff fences when matching files are present

## Testing
- bash -n .claude/scripts/daily.sh

------
https://chatgpt.com/codex/tasks/task_e_68d6504003e48330b078dae909c907fd